### PR TITLE
Honor Enumerable#each signature

### DIFF
--- a/src/callback/result_set.cr
+++ b/src/callback/result_set.cr
@@ -25,9 +25,9 @@ module Callback
       named.has_key?(name.to_s)
     end
 
-    def each
+    def each(&block : {String, T} -> _)
       named.each do |k, v|
-        yield k, v
+        yield({k, v})
       end
     end
   end


### PR DESCRIPTION
A `{String, T}` tuple should be yielded as a single value, and not a yield with a String and a T as two values.

I didn't find any spec or usages for `Callback::ResultSet` but I might be missing something.

Although this change was noticed for Crystal 0.30.0, it is something way before.